### PR TITLE
Release for v0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [v0.0.1](https://github.com/handlename/otomo/commits/v0.0.1) - 2025-06-14
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.9 to 1.29.12 by @dependabot in https://github.com/handlename/otomo/pull/3
+- chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot in https://github.com/handlename/otomo/pull/5
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/bedrockruntime from 1.26.1 to 1.28.0 by @dependabot in https://github.com/handlename/otomo/pull/4
+- chore(deps): bump github.com/alecthomas/kong from 1.9.0 to 1.10.0 by @dependabot in https://github.com/handlename/otomo/pull/9
+- chore(deps): bump github.com/samber/lo from 1.49.1 to 1.50.0 by @dependabot in https://github.com/handlename/otomo/pull/8
+- chore(deps): bump github.com/mackee/tanukirpc from 0.5.3 to 0.6.1 by @dependabot in https://github.com/handlename/otomo/pull/7
+- Introduce BrainThinker by @handlename in https://github.com/handlename/otomo/pull/12
+- chore(deps): bump github.com/fujiwara/ridge from 0.12.1 to 0.13.0 by @dependabot in https://github.com/handlename/otomo/pull/6
+- chore(deps): bump github.com/slack-go/slack from 0.16.0 to 0.17.0 by @dependabot in https://github.com/handlename/otomo/pull/10
+- chore(deps): bump github.com/alecthomas/kong from 1.10.0 to 1.11.0 by @dependabot in https://github.com/handlename/otomo/pull/11
+- Compare with Unix() by @handlename in https://github.com/handlename/otomo/pull/14

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package otomo
 
-const Version = "0.0.0"
+const Version = "0.0.1"


### PR DESCRIPTION
This pull request is for the next release as v0.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.9 to 1.29.12 by @dependabot in https://github.com/handlename/otomo/pull/3
* chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot in https://github.com/handlename/otomo/pull/5
* chore(deps): bump github.com/aws/aws-sdk-go-v2/service/bedrockruntime from 1.26.1 to 1.28.0 by @dependabot in https://github.com/handlename/otomo/pull/4
* chore(deps): bump github.com/alecthomas/kong from 1.9.0 to 1.10.0 by @dependabot in https://github.com/handlename/otomo/pull/9
* chore(deps): bump github.com/samber/lo from 1.49.1 to 1.50.0 by @dependabot in https://github.com/handlename/otomo/pull/8
* chore(deps): bump github.com/mackee/tanukirpc from 0.5.3 to 0.6.1 by @dependabot in https://github.com/handlename/otomo/pull/7
* Introduce BrainThinker by @handlename in https://github.com/handlename/otomo/pull/12
* chore(deps): bump github.com/fujiwara/ridge from 0.12.1 to 0.13.0 by @dependabot in https://github.com/handlename/otomo/pull/6
* chore(deps): bump github.com/slack-go/slack from 0.16.0 to 0.17.0 by @dependabot in https://github.com/handlename/otomo/pull/10
* chore(deps): bump github.com/alecthomas/kong from 1.10.0 to 1.11.0 by @dependabot in https://github.com/handlename/otomo/pull/11
* Compare with Unix() by @handlename in https://github.com/handlename/otomo/pull/14

## New Contributors
* @dependabot made their first contribution in https://github.com/handlename/otomo/pull/3
* @handlename made their first contribution in https://github.com/handlename/otomo/pull/12

**Full Changelog**: https://github.com/handlename/otomo/commits/v0.0.1