### PR TITLE
Compare with Unix()

### DIFF
--- a/internal/app/usecase/classify_slack_event_and_publish_test.go
+++ b/internal/app/usecase/classify_slack_event_and_publish_test.go
@@ -94,5 +94,5 @@ func Test_ClassifySlackEventAndPublish_handleAppMention(t *testing.T) {
 	assert.Equal(t, service.Time.UnixNanoToSlackID(now.UnixNano()), data.MessageID)
 	assert.Equal(t, service.Time.UnixNanoToSlackID(now.UnixNano()), data.ThreadID)
 	assert.Equal(t, "hello, otomo!", data.RawInstruction)
-	assert.Equal(t, service.Time.UnixNanoToSeconds(now.UnixNano()), service.Time.UnixNanoToSeconds(data.SentAt.UnixNano()))
+	assert.Equal(t, now.Unix(), data.SentAt.Unix())
 }


### PR DESCRIPTION
to fix flaky test like https://github.com/handlename/otomo/actions/runs/15514773846/job/43680304319?pr=1#step:4:93