### PR TITLE
Release for v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.2](https://github.com/handlename/otomo/compare/v0.0.1...v0.0.2) - 2025-06-14
+- Report test result by @handlename in https://github.com/handlename/otomo/pull/15
+- Fix release by goreleaser by @handlename in https://github.com/handlename/otomo/pull/17
+
 ## [v0.0.1](https://github.com/handlename/otomo/commits/v0.0.1) - 2025-06-14
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.9 to 1.29.12 by @dependabot in https://github.com/handlename/otomo/pull/3
 - chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot in https://github.com/handlename/otomo/pull/5

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package otomo
 
-const Version = "0.0.1"
+const Version = "0.0.2"


### PR DESCRIPTION
This pull request is for the next release as v0.0.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Report test result by @handlename in https://github.com/handlename/otomo/pull/15
* Fix release by goreleaser by @handlename in https://github.com/handlename/otomo/pull/17


**Full Changelog**: https://github.com/handlename/otomo/compare/v0.0.1...v0.0.2