### PR TITLE
Release for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [v0.1.0](https://github.com/handlename/otomo/compare/v0.0.2...v0.1.0) - 2026-06-14
+- Use format github-actions on Actions by @handlename in https://github.com/handlename/otomo/pull/18
+- Release only for linux by @handlename in https://github.com/handlename/otomo/pull/20
+- Format logs for CloudWatch Logs by @handlename in https://github.com/handlename/otomo/pull/21
+- Customize system prompt by @handlename in https://github.com/handlename/otomo/pull/22
+- remove Session by @handlename in https://github.com/handlename/otomo/pull/23
+- remove domain/repository.Context by @handlename in https://github.com/handlename/otomo/pull/24
+- chore(deps): bump github.com/mackee/tanukirpc from 0.6.1 to 0.7.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/31
+- chore(deps): bump github.com/go-playground/validator/v10 from 10.26.0 to 10.27.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/38
+- chore(deps): bump github.com/alecthomas/kong from 1.11.0 to 1.12.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/37
+- chore(deps): bump github.com/samber/lo from 1.50.0 to 1.51.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/26
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.14 to 1.30.2 by @dependabot[bot] in https://github.com/handlename/otomo/pull/32
+- chore(deps): bump github.com/slack-go/slack from 0.17.0 to 0.17.3 by @dependabot[bot] in https://github.com/handlename/otomo/pull/35
+- chore(deps): bump github.com/fujiwara/ridge from 0.13.0 to 0.13.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/33
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.36.3 to 1.37.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/36
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/bedrockruntime from 1.30.0 to 1.32.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/34
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.37.2 to 1.38.3 by @dependabot[bot] in https://github.com/handlename/otomo/pull/41
+- chore(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/39
+- chore(deps): bump github.com/samber/lo from 1.51.0 to 1.52.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/50
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.38.3 to 1.39.5 by @dependabot[bot] in https://github.com/handlename/otomo/pull/48
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/bedrockruntime from 1.35.0 to 1.42.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/47
+- chore(deps): bump github.com/alecthomas/kong from 1.12.1 to 1.13.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/51
+- chore(deps): bump github.com/go-playground/validator/v10 from 10.27.0 to 10.28.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/46
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.40.0 to 1.41.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/58
+- docs: add AI agent documentation by @handlename in https://github.com/handlename/otomo/pull/81
+- chore: ignore tmp/ by @handlename in https://github.com/handlename/otomo/pull/82
+- refactor: reorganize domain packages by context by @handlename in https://github.com/handlename/otomo/pull/83
+- Add permissions to start using new model by @handlename in https://github.com/handlename/otomo/pull/84
+- refactor: remove redundant domain layer interfaces by @handlename in https://github.com/handlename/otomo/pull/85
+
 ## [v0.0.2](https://github.com/handlename/otomo/compare/v0.0.1...v0.0.2) - 2025-06-14
 - Report test result by @handlename in https://github.com/handlename/otomo/pull/15
 - Fix release by goreleaser by @handlename in https://github.com/handlename/otomo/pull/17

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package otomo
 
-const Version = "0.0.2"
+const Version = "0.1.0"


### PR DESCRIPTION
This pull request is for the next release as v0.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Use format github-actions on Actions by @handlename in https://github.com/handlename/otomo/pull/18
* Release only for linux by @handlename in https://github.com/handlename/otomo/pull/20
* Format logs for CloudWatch Logs by @handlename in https://github.com/handlename/otomo/pull/21
* Customize system prompt by @handlename in https://github.com/handlename/otomo/pull/22
* remove Session by @handlename in https://github.com/handlename/otomo/pull/23
* remove domain/repository.Context by @handlename in https://github.com/handlename/otomo/pull/24
* chore(deps): bump github.com/mackee/tanukirpc from 0.6.1 to 0.7.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/31
* chore(deps): bump github.com/go-playground/validator/v10 from 10.26.0 to 10.27.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/38
* chore(deps): bump github.com/alecthomas/kong from 1.11.0 to 1.12.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/37
* chore(deps): bump github.com/samber/lo from 1.50.0 to 1.51.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/26
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.29.14 to 1.30.2 by @dependabot[bot] in https://github.com/handlename/otomo/pull/32
* chore(deps): bump github.com/slack-go/slack from 0.17.0 to 0.17.3 by @dependabot[bot] in https://github.com/handlename/otomo/pull/35
* chore(deps): bump github.com/fujiwara/ridge from 0.13.0 to 0.13.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/33
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.36.3 to 1.37.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/36
* chore(deps): bump github.com/aws/aws-sdk-go-v2/service/bedrockruntime from 1.30.0 to 1.32.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/34
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.37.2 to 1.38.3 by @dependabot[bot] in https://github.com/handlename/otomo/pull/41
* chore(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/39
* chore(deps): bump github.com/samber/lo from 1.51.0 to 1.52.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/50
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.38.3 to 1.39.5 by @dependabot[bot] in https://github.com/handlename/otomo/pull/48
* chore(deps): bump github.com/aws/aws-sdk-go-v2/service/bedrockruntime from 1.35.0 to 1.42.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/47
* chore(deps): bump github.com/alecthomas/kong from 1.12.1 to 1.13.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/51
* chore(deps): bump github.com/go-playground/validator/v10 from 10.27.0 to 10.28.0 by @dependabot[bot] in https://github.com/handlename/otomo/pull/46
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.40.0 to 1.41.1 by @dependabot[bot] in https://github.com/handlename/otomo/pull/58
* docs: add AI agent documentation by @handlename in https://github.com/handlename/otomo/pull/81
* chore: ignore tmp/ by @handlename in https://github.com/handlename/otomo/pull/82
* refactor: reorganize domain packages by context by @handlename in https://github.com/handlename/otomo/pull/83
* Add permissions to start using new model by @handlename in https://github.com/handlename/otomo/pull/84
* refactor: remove redundant domain layer interfaces by @handlename in https://github.com/handlename/otomo/pull/85


**Full Changelog**: https://github.com/handlename/otomo/compare/v0.0.2...v0.1.0