### PR TITLE
Format logs for CloudWatch Logs

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -31,7 +31,7 @@ func Run() ExitCode {
 		return ExitCodeError
 	}
 
-	otomo.InitLogger(root.LogLevel)
+	otomo.InitLogger(root.LogLevel, root.LogConsole)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()

--- a/cli/command/root.go
+++ b/cli/command/root.go
@@ -5,8 +5,9 @@ import "github.com/alecthomas/kong"
 type Root struct {
 	ConfigPath string `help:"Path to config file." default:"config.toml"`
 
-	LogLevel string           `help:"Set log level. (trace|debug|info|warn|error|panic)" default:"info"`
-	Version  kong.VersionFlag `help:"Show version."`
+	LogLevel   string           `help:"Set log level. (trace|debug|info|warn|error|panic)" default:"info"`
+	LogConsole bool             `help:"Write logs for console." default:"true" negatable:""`
+	Version    kong.VersionFlag `help:"Show version."`
 
 	Server Server `cmd:"" help:"Run as server"`
 }

--- a/lambda/bootstrap
+++ b/lambda/bootstrap
@@ -1,4 +1,7 @@
 #!/bin/sh
 
 cd $LAMBDA_TASK_ROOT
-./ssmwrap -env 'path=/otomo/*' -- ./app --log-level debug server
+./ssmwrap -env 'path=/otomo/*' -- \
+    ./app \
+    --log-level debug server \
+    --no-log-console

--- a/logger.go
+++ b/logger.go
@@ -17,15 +17,14 @@ func InitLogger(level string) {
 	log.Logger = log.Output(zerolog.ConsoleWriter{
 		Out:        os.Stderr,
 		TimeFormat: time.RFC3339,
+		NoColor:    !color,
 	})
 
 	switch strings.ToLower(level) {
 	case "trace":
 		zerolog.SetGlobalLevel(zerolog.TraceLevel)
-		log.Logger = log.With().Caller().Logger()
 	case "debug":
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-		log.Logger = log.With().Caller().Logger()
 	case "info":
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	case "warn":

--- a/logger.go
+++ b/logger.go
@@ -1,6 +1,7 @@
 package otomo
 
 import (
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -10,15 +11,10 @@ import (
 	"github.com/rs/zerolog/pkgerrors"
 )
 
-func InitLogger(level string) {
+func InitLogger(level string, console bool) {
 	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
-
-	log.Logger = log.Output(zerolog.ConsoleWriter{
-		Out:        os.Stderr,
-		TimeFormat: time.RFC3339,
-		NoColor:    !color,
-	})
+	log.Logger = log.Output(logWriter(console)).With().Caller().Logger()
 
 	switch strings.ToLower(level) {
 	case "trace":
@@ -37,4 +33,14 @@ func InitLogger(level string) {
 		// fallback to `info`
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
+}
+
+func logWriter(console bool) io.Writer {
+	if console {
+		return zerolog.ConsoleWriter{
+			Out:        os.Stderr,
+			TimeFormat: time.RFC3339,
+		}
+	}
+	return os.Stderr
 }


### PR DESCRIPTION
- Added `--[no]-log-console` option.
- Always add filename and line to logs