### PR TITLE
feat: error feedback for chat processing failures

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -168,6 +168,11 @@ bot_user_id = "@U08K30DRHRP"
 bot_token = "{{ must_env `SLACK_BOT_TOKEN` }}"
 app_token = "{{ must_env `SLACK_APP_TOKEN` }}"
 
+[slack.error_feedback]
+enable_reaction = true
+reaction_emoji = "warning"
+enable_post_snippet = false
+
 [bedrock]
 model_type = "claude"
 model_id = "{{ must_env `BEDROCK_MODEL_ID` }}"

--- a/config/config.go
+++ b/config/config.go
@@ -15,10 +15,38 @@ type Root struct {
 }
 
 type Slack struct {
-	SigningSecret string `toml:"signing_secret" validate:"required"`
-	BotUserID     string `toml:"bot_user_id" validate:"required"`
-	BotToken      string `toml:"bot_token" validate:"required"`
-	AppToken      string `toml:"app_token" validate:"required"`
+	SigningSecret string        `toml:"signing_secret" validate:"required"`
+	BotUserID     string        `toml:"bot_user_id" validate:"required"`
+	BotToken      string        `toml:"bot_token" validate:"required"`
+	AppToken      string        `toml:"app_token" validate:"required"`
+	ErrorFeedback ErrorFeedback `toml:"error_feedback"`
+}
+
+type ErrorFeedback struct {
+	EnableReaction    *bool  `toml:"enable_reaction"`
+	ReactionEmoji     string `toml:"reaction_emoji"`
+	EnablePostSnippet *bool  `toml:"enable_post_snippet"`
+}
+
+func (e ErrorFeedback) GetEnableReaction() bool {
+	if e.EnableReaction == nil {
+		return true
+	}
+	return *e.EnableReaction
+}
+
+func (e ErrorFeedback) GetReactionEmoji() string {
+	if e.ReactionEmoji == "" {
+		return "warning"
+	}
+	return e.ReactionEmoji
+}
+
+func (e ErrorFeedback) GetEnablePostSnippet() bool {
+	if e.EnablePostSnippet == nil {
+		return false
+	}
+	return *e.EnablePostSnippet
 }
 
 type LLM struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_ErrorFeedbackDefaults(t *testing.T) {
+	// Create temporary TOML config without error_feedback section
+	content := `
+port = 8080
+[slack]
+signing_secret = "secret"
+bot_user_id = "@U123"
+bot_token = "xoxb-token"
+app_token = "xapp-token"
+[llm]
+model_type = "claude"
+model_id = "anthropic"
+`
+	tmpFile, err := os.CreateTemp("", "config_test_*.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	err = Load(tmpFile.Name())
+	require.NoError(t, err)
+
+	// Verify defaults resolved
+	assert.True(t, Config.Slack.ErrorFeedback.GetEnableReaction())
+	assert.Equal(t, "warning", Config.Slack.ErrorFeedback.GetReactionEmoji())
+	assert.False(t, Config.Slack.ErrorFeedback.GetEnablePostSnippet())
+}
+
+func TestConfig_ErrorFeedbackOverrides(t *testing.T) {
+	// Create temporary TOML config with error_feedback overrides
+	content := `
+port = 8080
+[slack]
+signing_secret = "secret"
+bot_user_id = "@U123"
+bot_token = "xoxb-token"
+app_token = "xapp-token"
+[slack.error_feedback]
+enable_reaction = false
+reaction_emoji = "boom"
+enable_post_snippet = true
+[llm]
+model_type = "claude"
+model_id = "anthropic"
+`
+	tmpFile, err := os.CreateTemp("", "config_test_*.toml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	err = Load(tmpFile.Name())
+	require.NoError(t, err)
+
+	// Verify overrides resolved
+	assert.False(t, Config.Slack.ErrorFeedback.GetEnableReaction())
+	assert.Equal(t, "boom", Config.Slack.ErrorFeedback.GetReactionEmoji())
+	assert.True(t, Config.Slack.ErrorFeedback.GetEnablePostSnippet())
+}

--- a/internal/app/service/messenger.go
+++ b/internal/app/service/messenger.go
@@ -10,4 +10,5 @@ type Messenger interface {
 	PostMessage(ctx context.Context, channelID, messageID, msg string) error
 	AddReaction(ctx context.Context, channelID, messageID string, emoji string) error
 	FetchThread(ctx context.Context, channelID, threadID string) (*chat.Thread, error)
+	UploadFile(ctx context.Context, channelID, threadTS, filename, content string) error
 }

--- a/internal/app/usecase/reply.go
+++ b/internal/app/usecase/reply.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 
+	"github.com/handlename/otomo/config"
 	appservice "github.com/handlename/otomo/internal/app/service"
 	"github.com/handlename/otomo/internal/domain/chat"
 	"github.com/handlename/otomo/internal/domain/core"
@@ -36,6 +37,7 @@ func (r *Reply) Run(ctx context.Context, input ReplyInput) (*ReplyOutput, error)
 	if input.EventData.ThreadID != "" {
 		thread, err := r.slack.FetchThread(ctx, input.EventData.ChannelID, input.EventData.ThreadID)
 		if err != nil {
+			r.handleError(ctx, input.EventData, err)
 			return nil, failure.Wrap(err)
 		}
 
@@ -55,11 +57,41 @@ func (r *Reply) Run(ctx context.Context, input ReplyInput) (*ReplyOutput, error)
 
 	rep, err := r.otomo.Think(ctx, c)
 	if err != nil {
+		r.handleError(ctx, input.EventData, err)
 		return nil, failure.Wrap(err)
 	}
 
 	err = r.slack.PostMessage(ctx, input.EventData.ChannelID, input.EventData.MessageID, rep.Body())
-	return &ReplyOutput{}, err
+	if err != nil {
+		r.handleError(ctx, input.EventData, err)
+		return nil, failure.Wrap(err)
+	}
+	return &ReplyOutput{}, nil
+}
+
+func (r *Reply) handleError(ctx context.Context, data chat.InstructionReceivedData, targetErr error) {
+	cfg := config.Config.Slack.ErrorFeedback
+
+	var threadTS string
+	if data.ThreadID != "" {
+		threadTS = data.ThreadID
+	} else {
+		threadTS = data.MessageID
+	}
+
+	if cfg.GetEnableReaction() {
+		emoji := cfg.GetReactionEmoji()
+		if err := r.slack.AddReaction(ctx, data.ChannelID, data.MessageID, emoji); err != nil {
+			log.Error().Err(err).Msg("failed to add error reaction emoji")
+		}
+	}
+
+	if cfg.GetEnablePostSnippet() {
+		errContent := targetErr.Error()
+		if err := r.slack.UploadFile(ctx, data.ChannelID, threadTS, "error.txt", errContent); err != nil {
+			log.Error().Err(err).Msg("failed to upload error snippet")
+		}
+	}
 }
 
 func (r *Reply) Subscribe(publisher appservice.Publisher) {

--- a/internal/app/usecase/reply_test.go
+++ b/internal/app/usecase/reply_test.go
@@ -2,9 +2,11 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/handlename/otomo/config"
 	"github.com/handlename/otomo/internal/domain/chat"
 	"github.com/handlename/otomo/internal/domain/reasoning"
 	"github.com/handlename/otomo/internal/infra/brain"
@@ -143,4 +145,67 @@ func Test_Reply_Run_Error(t *testing.T) {
 
 	// Verify messenger was not called
 	assert.Equal(t, 0, len(mockMessenger.History))
+}
+
+func TestReply_Run_ErrorFeedback(t *testing.T) {
+	originalConfig := config.Config
+	defer func() { config.Config = originalConfig }()
+
+	t.Run("default error feedback (reaction only)", func(t *testing.T) {
+		config.Config.Slack.ErrorFeedback = config.ErrorFeedback{}
+
+		mockMessenger := &service.MockMessenger{}
+		mockOtomo := chat.NewOtomo(reasoning.NewBrain(&brain.Mock{
+			ThinkFunc: func(ctx context.Context, c *reasoning.Context) (*reasoning.Answer, error) {
+				return nil, errors.New("thinking error")
+			},
+		}))
+		uc := NewReply(mockOtomo, mockMessenger)
+
+		_, err := uc.Run(t.Context(), ReplyInput{
+			EventData: chat.InstructionReceivedData{
+				ChannelID:      "C12345",
+				MessageID:      "1234567890.123456",
+				RawInstruction: "hello",
+			},
+		})
+		assert.Error(t, err)
+
+		require.Equal(t, 1, len(mockMessenger.ReactionHistory))
+		assert.Equal(t, "warning", mockMessenger.ReactionHistory[0].Emoji)
+		assert.Equal(t, "C12345", mockMessenger.ReactionHistory[0].ChannelID)
+		assert.Equal(t, "1234567890.123456", mockMessenger.ReactionHistory[0].MessageID)
+
+		assert.Equal(t, 0, len(mockMessenger.UploadFileHistory))
+	})
+
+	t.Run("snippet posting enabled", func(t *testing.T) {
+		enableSnippet := true
+		config.Config.Slack.ErrorFeedback = config.ErrorFeedback{
+			EnablePostSnippet: &enableSnippet,
+		}
+
+		mockMessenger := &service.MockMessenger{}
+		mockOtomo := chat.NewOtomo(reasoning.NewBrain(&brain.Mock{
+			ThinkFunc: func(ctx context.Context, c *reasoning.Context) (*reasoning.Answer, error) {
+				return nil, errors.New("thinking error detail")
+			},
+		}))
+		uc := NewReply(mockOtomo, mockMessenger)
+
+		_, err := uc.Run(t.Context(), ReplyInput{
+			EventData: chat.InstructionReceivedData{
+				ChannelID:      "C12345",
+				MessageID:      "1234567890.123456",
+				RawInstruction: "hello",
+			},
+		})
+		assert.Error(t, err)
+
+		assert.Equal(t, 1, len(mockMessenger.ReactionHistory))
+		require.Equal(t, 1, len(mockMessenger.UploadFileHistory))
+		assert.Equal(t, "C12345", mockMessenger.UploadFileHistory[0].ChannelID)
+		assert.Equal(t, "1234567890.123456", mockMessenger.UploadFileHistory[0].ThreadTS)
+		assert.Contains(t, mockMessenger.UploadFileHistory[0].Content, "thinking error detail")
+	})
 }

--- a/internal/infra/service/mock_messenger.go
+++ b/internal/infra/service/mock_messenger.go
@@ -10,11 +10,19 @@ import (
 
 var _ aservice.Messenger = (*MockMessenger)(nil)
 
+type UploadFileCall struct {
+	ChannelID string
+	ThreadTS  string
+	Filename  string
+	Content   string
+}
+
 // MockMessenger is a mock implementation of service.Messenger
 type MockMessenger struct {
 	PostMessageFunc func(ctx context.Context, channelID, messageID, message string) error
 	AddReactionFunc func(ctx context.Context, channelID, messageID string, emoji string) error
 	FetchThreadFunc func(ctx context.Context, channelID string, threadID string) (*chat.Thread, error)
+	UploadFileFunc  func(ctx context.Context, channelID, threadTS, filename, content string) error
 
 	History []struct {
 		ChannelID string
@@ -26,6 +34,7 @@ type MockMessenger struct {
 		MessageID string
 		Emoji     string
 	}
+	UploadFileHistory []UploadFileCall
 }
 
 // FetchThread implements service.Messenger.
@@ -77,3 +86,18 @@ func (m *MockMessenger) AddReaction(ctx context.Context, channelID, messageID st
 
 	return nil
 }
+
+// UploadFile implements service.Messenger.
+func (m *MockMessenger) UploadFile(ctx context.Context, channelID, threadTS, filename, content string) error {
+	m.UploadFileHistory = append(m.UploadFileHistory, UploadFileCall{
+		ChannelID: channelID,
+		ThreadTS:  threadTS,
+		Filename:  filename,
+		Content:   content,
+	})
+	if m.UploadFileFunc != nil {
+		return m.UploadFileFunc(ctx, channelID, threadTS, filename, content)
+	}
+	return nil
+}
+

--- a/internal/infra/service/mock_messenger_test.go
+++ b/internal/infra/service/mock_messenger_test.go
@@ -1,0 +1,62 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/handlename/otomo/internal/infra/service"
+)
+
+func TestMockMessenger_UploadFile(t *testing.T) {
+	mock := &service.MockMessenger{}
+
+	ctx := context.Background()
+	err := mock.UploadFile(ctx, "chan-id", "ts-1234", "test.txt", "test content")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mock.UploadFileHistory) != 1 {
+		t.Fatalf("expected 1 upload call, got %d", len(mock.UploadFileHistory))
+	}
+
+	call := mock.UploadFileHistory[0]
+	if call.ChannelID != "chan-id" {
+		t.Errorf("expected ChannelID to be 'chan-id', got '%s'", call.ChannelID)
+	}
+	if call.ThreadTS != "ts-1234" {
+		t.Errorf("expected ThreadTS to be 'ts-1234', got '%s'", call.ThreadTS)
+	}
+	if call.Filename != "test.txt" {
+		t.Errorf("expected Filename to be 'test.txt', got '%s'", call.Filename)
+	}
+	if call.Content != "test content" {
+		t.Errorf("expected Content to be 'test content', got '%s'", call.Content)
+	}
+}
+
+func TestMockMessenger_UploadFileFunc(t *testing.T) {
+	customErr := errors.New("custom upload error")
+	var called bool
+	mock := &service.MockMessenger{
+		UploadFileFunc: func(ctx context.Context, channelID, threadTS, filename, content string) error {
+			called = true
+			if channelID != "chan-id" || threadTS != "ts-1234" || filename != "test.txt" || content != "test content" {
+				t.Errorf("unexpected parameters in mock func")
+			}
+			return customErr
+		},
+	}
+
+	ctx := context.Background()
+	err := mock.UploadFile(ctx, "chan-id", "ts-1234", "test.txt", "test content")
+	if !errors.Is(err, customErr) {
+		t.Fatalf("expected custom error, got %v", err)
+	}
+
+	if !called {
+		t.Error("expected UploadFileFunc to be called")
+	}
+}
+

--- a/internal/infra/service/nop_slack.go
+++ b/internal/infra/service/nop_slack.go
@@ -28,3 +28,9 @@ func (n *NopSlack) PostMessage(ctx context.Context, channelID string, messageID 
 	n.Memory += msg
 	return nil
 }
+
+// UploadFile implements service.Messenger.
+func (n *NopSlack) UploadFile(ctx context.Context, channelID, threadTS, filename, content string) error {
+	return nil
+}
+

--- a/internal/infra/service/slack.go
+++ b/internal/infra/service/slack.go
@@ -114,3 +114,15 @@ func (s *Slack) fetchThread(ctx context.Context, channelID, threadID, cursor str
 
 	return msgs, more, next, nil
 }
+
+// UploadFile implements service.Messenger.
+func (s *Slack) UploadFile(ctx context.Context, channelID, threadTS, filename, content string) error {
+	_, err := s.client.UploadFileV2Context(ctx, slack.UploadFileV2Parameters{
+		Channel:         channelID,
+		ThreadTimestamp: threadTS,
+		Filename:        filename,
+		Content:         content,
+	})
+	return err
+}
+

--- a/internal/infra/service/slack.go
+++ b/internal/infra/service/slack.go
@@ -122,6 +122,7 @@ func (s *Slack) UploadFile(ctx context.Context, channelID, threadTS, filename, c
 		ThreadTimestamp: threadTS,
 		Filename:        filename,
 		Content:         content,
+		FileSize:        len(content),
 	})
 	return err
 }


### PR DESCRIPTION
## Why this change is necessary
When errors occur during Slack chat processing (e.g., AI reasoning failure, Slack API post failures), users currently receive no visual feedback on the failure, leading to confusion. We need a way to notify users that an error happened.

## Approach
Implement a configurable error feedback mechanism:
1. **Reactions**: Add a warning reaction to the target message (enabled by default).
2. **Snippets**: Upload a text snippet of the error details to the thread (disabled by default).

These options are controlled via configuration values in `config.toml` under `[slack.error_feedback]`. We updated the `Messenger` interface to support `UploadFile`, implemented the method in the Slack infrastructure layer using Slack's modern files upload V2 API (`UploadFileV2Context`), and caught failures in the `Reply` usecase to trigger `handleError`.

## Design Documents
<details>
<summary>2026-06-15-error-feedback-design.md (Click to expand)</summary>

# Error Feedback System for Slack Bot

### 1. Background & Goals
When an error occurs during chat message processing (e.g., AI fails to respond, Slack API communication fails), users currently receive no visual feedback on the failure. This design specifies a feedback mechanism to notify users of failures via:
1. **Reactions**: Adding an emoji reaction (default: `:warning:`) to the target message (enabled by default).
2. **Error Snippets**: Uploading a text snippet file containing the error details to the thread (disabled by default).

These feedback methods will be configurable in `config.toml`.

### 2. Configuration Design
We will add a new sub-section under `[slack]` in `config.toml` to manage feedback behaviors.
We will update `Slack` and `ErrorFeedback` structs in `config/config.go`.
- `EnableReaction`: Defaults to `true` if omitted.
- `ReactionEmoji`: Defaults to `"warning"` if omitted.
- `EnablePostSnippet`: Defaults to `false` if omitted.

### 3. Interface and Implementation Details
- `Messenger` Interface Update: We will add `UploadFile` to the service abstraction layer.
- Slack Client Implementation: We will implement the new method using the recommended Slack API (`files.getUploadURLExternal` and `files.completeUploadExternal` via `slack-go`'s `UploadFileV2Context`).
- Test & Development Mock Updates: `nop_slack.go` and `mock_messenger.go` will be updated to implement the `UploadFile` method.

### 4. Error Handling Flow in Usecase
The `Reply` usecase will catch any failures and trigger `handleError`.
If enabled, it will add an emoji reaction to the target message and upload the error detail snippet to the thread.

### 5. Testing Strategy
- Unit Tests: Assert default reaction behavior, check disabled behavior, and assert snippet uploading when enabled.
- Integration Verification: Run tests using standard command `go test ./...`

</details>

## Review Points
- Make sure that default parameters resolve properly if configuration blocks are missing in TOML.
- Check that the `UploadFile` implementation successfully utilizes `slack.UploadFileV2Parameters{..., FileSize: len(content)}` to avoid size errors on Slack side.
