### PR TITLE
docs: require English for git commits, GitHub issues, and PR summaries in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 ## Comments
 - Write comments in English
 - Write comments only when structures or operations are complex
+- Write git commit messages, GitHub issue descriptions, and Pull Request summaries in English
 
 ## Testing
 - Use the command `go test -v {package path} {test function name}` when running tests


### PR DESCRIPTION
Appends the English documentation guideline to the Comments section of AGENTS.md.