### PR TITLE
feat(infra): use markdown block for slack messages

### DIFF
--- a/internal/infra/service/slack.go
+++ b/internal/infra/service/slack.go
@@ -53,10 +53,12 @@ func (s *Slack) Verify(header http.Header, body []byte) error {
 }
 
 func (s *Slack) PostMessage(ctx context.Context, channelID core.ChannelID, messageID core.MessageID, msg chat.ReplyBody) error {
+	block := slack.NewMarkdownBlock("", string(msg))
 	_, _, err := s.client.PostMessage(
 		channelID.Value(),
 		slack.MsgOptionTS(messageID.Value()),
-		slack.MsgOptionText(string(msg), false),
+		slack.MsgOptionText(string(msg), false), // fallback text
+		slack.MsgOptionBlocks(block),
 	)
 	return err
 }

--- a/internal/infra/service/slack.go
+++ b/internal/infra/service/slack.go
@@ -54,13 +54,17 @@ func (s *Slack) Verify(header http.Header, body []byte) error {
 
 func (s *Slack) PostMessage(ctx context.Context, channelID core.ChannelID, messageID core.MessageID, msg chat.ReplyBody) error {
 	block := slack.NewMarkdownBlock("", string(msg))
-	_, _, err := s.client.PostMessage(
+	_, _, err := s.client.PostMessageContext(
+		ctx,
 		channelID.Value(),
 		slack.MsgOptionTS(messageID.Value()),
 		slack.MsgOptionText(string(msg), false), // fallback text
 		slack.MsgOptionBlocks(block),
 	)
-	return err
+	if err != nil {
+		return failure.Wrap(err)
+	}
+	return nil
 }
 
 func (s *Slack) AddReaction(ctx context.Context, channelID core.ChannelID, messageID core.MessageID, emoji string) error {


### PR DESCRIPTION
## Why this change is necessary
Standard markdown formatting (like `**bold**`, `[link](url)`) in messages sent to Slack from Otomo was previously rendered as plain text. To fix this, we need to instruct Slack to format standard markdown correctly by using the Block Kit `markdown` block.

## Approach
- Modified `internal/infra/service/slack.go`'s `PostMessage` method to wrap the outgoing message in a `slack.MarkdownBlock` and send it via `slack.MsgOptionBlocks`.
- Preserved `slack.MsgOptionText` for fallback previews/notifications.
- Refactored `PostMessage` to use the context-aware `PostMessageContext` method and wrapped external Slack errors with `failure.Wrap`.

## Design Documents
<details>
<summary>slack_markdown_block_design.md (Click to expand)</summary>

# Design Spec: Slack Markdown Block Integration

## 1. Background & Purpose
Currently, messages sent to Slack from Otomo contain standard markdown formatting (e.g., `**bold**`, `[link](url)`), which is rendered as plain text on Slack because Slack does not natively parse standard markdown in normal text payloads. 

To solve this, we will transition the message delivery to use Slack's new `markdown` block type in Block Kit. This block type instructs Slack to parse standard markdown natively, ensuring bold, italic, links, lists, and other elements render correctly.

## 2. Architecture & Components
This change is localized within the **Infrastructure Layer**, keeping the Application and Domain layers isolated from Slack-specific payload details.

- **Interface**: `Messenger` (`internal/app/service/messenger.go`) - No change.
- **Implementation**: `Slack` (`internal/infra/service/slack.go`) - Modify the `PostMessage` method to build and send a `MarkdownBlock`.

```
┌──────────────────────────────────────┐
│          Application Layer           │
│   Use Case calls PostMessage(msg)   │
└──────────────────┬───────────────────┘
                   │ (chat.ReplyBody - standard Markdown)
                   ▼
┌──────────────────────────────────────┐
│         Infrastructure Layer         │
│   Slack.PostMessage wraps msg in     │
│   slack.MarkdownBlock and posts      │
└──────────────────────────────────────┘
```

## 3. Proposed Changes

### `internal/infra/service/slack.go`
Modify the `PostMessage` method:
- Create a `slack.MarkdownBlock` using `slack.NewMarkdownBlock("", string(msg))`.
- Pass it to `PostMessage` using `slack.MsgOptionBlocks(block)`.
- Keep `slack.MsgOptionText(string(msg), false)` as a fallback for push notifications and preview panels.

```go
func (s *Slack) PostMessage(ctx context.Context, channelID core.ChannelID, messageID core.MessageID, msg chat.ReplyBody) error {
	block := slack.NewMarkdownBlock("", string(msg))
	_, _, err := s.client.PostMessage(
		channelID.Value(),
		slack.MsgOptionTS(messageID.Value()),
		slack.MsgOptionText(string(msg), false), // fallback text
		slack.MsgOptionBlocks(block),
	)
	return err
}
```

## 4. Test Plan
- Run existing tests to ensure no regressions in other areas:
  ```bash
  go test ./...
  ```
- Run compilation and dependency verification.

</details>

## Review Points
- Verify that standard markdown formatting functions correctly inside Slack messages.
- Ensure context propagation and error handling via `failure.Wrap` in `PostMessageContext` look solid.
