### PR TITLE
Release for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.3.0](https://github.com/handlename/otomo/compare/v0.2.0...v0.3.0) - 2026-06-28
+- feat(infra): use markdown block for slack messages by @handlename in https://github.com/handlename/otomo/pull/100
+- feat: implement interactive terminal chat TUI by @handlename in https://github.com/handlename/otomo/pull/102
+- feat: integrate local MCP server into CLI chat by @handlename in https://github.com/handlename/otomo/pull/104
+- chore: migrate task execution from make to mise by @handlename in https://github.com/handlename/otomo/pull/103
+- feat(mcp): return standard errors from post_message by @handlename in https://github.com/handlename/otomo/pull/105
+- feat: implement OpenTelemetry tracing integration by @handlename in https://github.com/handlename/otomo/pull/106
+- feat(trace): support local Jaeger tracing via Docker by @handlename in https://github.com/handlename/otomo/pull/107
+
 ## [v0.2.0](https://github.com/handlename/otomo/compare/v0.1.0...v0.2.0) - 2026-06-21
 - feat: error feedback for chat processing failures by @handlename in https://github.com/handlename/otomo/pull/86
 - chore(deps): bump github.com/go-playground/validator/v10 from 10.28.0 to 10.30.2 by @dependabot[bot] in https://github.com/handlename/otomo/pull/67

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package otomo
 
-const Version = "0.2.0"
+const Version = "0.3.0"


### PR DESCRIPTION
This pull request is for the next release as v0.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat(infra): use markdown block for slack messages by @handlename in https://github.com/handlename/otomo/pull/100
* feat: implement interactive terminal chat TUI by @handlename in https://github.com/handlename/otomo/pull/102
* feat: integrate local MCP server into CLI chat by @handlename in https://github.com/handlename/otomo/pull/104
* chore: migrate task execution from make to mise by @handlename in https://github.com/handlename/otomo/pull/103
* feat(mcp): return standard errors from post_message by @handlename in https://github.com/handlename/otomo/pull/105
* feat: implement OpenTelemetry tracing integration by @handlename in https://github.com/handlename/otomo/pull/106
* feat(trace): support local Jaeger tracing via Docker by @handlename in https://github.com/handlename/otomo/pull/107


**Full Changelog**: https://github.com/handlename/otomo/compare/v0.2.0...v0.3.0