### PR TITLE
feat(mcp): return standard errors from post_message

### DIFF
--- a/internal/infra/ui/mcp/server.go
+++ b/internal/infra/ui/mcp/server.go
@@ -25,9 +25,14 @@ type PostMessageOutput struct {
 	Response string `json:"response" jsonschema:"The response from otomo"`
 }
 
-type McpRequestMsg struct {
+type MCPResponse struct {
+	Response string
+	Error    error
+}
+
+type MCPRequestMsg struct {
 	Prompt    string
-	ReplyChan chan string
+	ReplyChan chan MCPResponse
 }
 
 func NewServer(port int, p *tea.Program) *Server {
@@ -49,16 +54,19 @@ func (s *Server) Start(ctx context.Context) error {
 		Name:        "post_message",
 		Description: "Post a message to the active otomo chat TUI session and retrieve the response.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input PostMessageInput) (*mcp.CallToolResult, PostMessageOutput, error) {
-		replyChan := make(chan string, 1)
+		replyChan := make(chan MCPResponse, 1)
 
-		s.p.Send(McpRequestMsg{
+		s.p.Send(MCPRequestMsg{
 			Prompt:    input.Message,
 			ReplyChan: replyChan,
 		})
 
 		select {
 		case reply := <-replyChan:
-			return nil, PostMessageOutput{Response: reply}, nil
+			if reply.Error != nil {
+				return nil, PostMessageOutput{}, reply.Error
+			}
+			return nil, PostMessageOutput{Response: reply.Response}, nil
 		case <-ctx.Done():
 			return nil, PostMessageOutput{}, ctx.Err()
 		case <-time.After(2 * time.Minute):

--- a/internal/infra/ui/mcp/server.go
+++ b/internal/infra/ui/mcp/server.go
@@ -54,6 +54,10 @@ func (s *Server) Start(ctx context.Context) error {
 		Name:        "post_message",
 		Description: "Post a message to the active otomo chat TUI session and retrieve the response.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, input PostMessageInput) (*mcp.CallToolResult, PostMessageOutput, error) {
+		if s.p == nil {
+			return nil, PostMessageOutput{}, fmt.Errorf("TUI program is not initialized")
+		}
+
 		replyChan := make(chan MCPResponse, 1)
 
 		s.p.Send(MCPRequestMsg{

--- a/internal/infra/ui/terminal/chat_tui.go
+++ b/internal/infra/ui/terminal/chat_tui.go
@@ -129,7 +129,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.spinner, cmd = m.spinner.Update(msg)
 			cmds = append(cmds, cmd)
 		}
-	case mcp.McpRequestMsg:
+	case mcp.MCPRequestMsg:
 		m.userInputVal = msg.Prompt
 		m.thinking = true
 		m.textInput.Blur()
@@ -146,9 +146,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				ans, err := usecase.ExecuteToolLoop(m.ctx, m.otomo, c, m.tools)
 				if err == nil {
-					msg.ReplyChan <- string(ans.Body())
+					msg.ReplyChan <- mcp.MCPResponse{Response: string(ans.Body())}
 				} else {
-					msg.ReplyChan <- fmt.Sprintf("Error: %v", err)
+					msg.ReplyChan <- mcp.MCPResponse{Error: err}
 				}
 				return thinkResultMsg{ans: ans, err: err}
 			},


### PR DESCRIPTION
## Why this change is necessary
When calling the MCP `post_message` tool, if the tool execution loop in the Bubble Tea TUI failed (e.g., LLM reasoning or Bedrock invocation failed), the error was formatted as a simple string output in a successful response. This made it impossible for the MCP client/caller (like an LLM) to detect that the tool call had failed, preventing it from self-correcting or handling the error properly.

## Approach
- Introduced `MCPResponse` to encapsulate both successful responses and errors.
- Updated `MCPRequestMsg`'s channel type to pass `MCPResponse` objects instead of raw strings.
- Modified the TUI message handler to catch tool execution errors from `ExecuteToolLoop` and send them back via `MCPResponse`.
- Updated the MCP tool handler to return the propagated error to the MCP SDK on failure, which automatically responds to the MCP client with `IsError: true`.
- Added a nil safety check for the TUI program reference `s.p` in the tool handler.

## Design Documents
<details>
<summary>2026-06-27-mcp-error-handling-design.md (Click to expand)</summary>

# Spec: MCP Error Handling

## Background
The `otomo` codebase includes an MCP (Model Context Protocol) server that exposes a `post_message` tool. This tool sends messages to the active `otomo` chat TUI session (a Bubbletea program), waits for the execution (including tools) to finish, and returns the response back to the MCP client.

Currently, if the execution in `ExecuteToolLoop` fails, the error is formatted as a string `"Error: %v"` and returned as a normal successful response text. This makes it impossible for the MCP client (such as an LLM) to detect that the tool call actually failed, preventing it from self-correcting or handling the error properly.

## Goal
Improve error handling in the MCP `post_message` tool such that execution errors from `ExecuteToolLoop` are returned to the MCP client via the standard MCP error mechanism (`isError: true` in the tool result with the error message in the content).

## Proposed Changes

### 1. Define `MCPResponse` in `internal/infra/ui/mcp/server.go`
We will introduce a struct that holds the outcome of a message dispatch, including both the response string and any error encountered:

```go
type MCPResponse struct {
	Response string
	Error    error
}
```

### 2. Update `MCPRequestMsg` in `internal/infra/ui/mcp/server.go`
We will update `MCPRequestMsg`'s channel type to pass `MCPResponse` instead of a plain string:

```go
type MCPRequestMsg struct {
	Prompt    string
	ReplyChan chan MCPResponse
}
```

### 3. Update the TUI message handler in `internal/infra/ui/terminal/chat_tui.go`
When processing `mcp.MCPRequestMsg`, send the success response or the execution error using `mcp.MCPResponse`:

```go
ans, err := usecase.ExecuteToolLoop(m.ctx, m.otomo, c, m.tools)
if err == nil {
	msg.ReplyChan <- mcp.MCPResponse{Response: string(ans.Body())}
} else {
	msg.ReplyChan <- mcp.MCPResponse{Error: err}
}
```

### 4. Update the MCP Server Tool handler in `internal/infra/ui/mcp/server.go`
Inside the `post_message` tool handler:
- Update channel initialization to `make(chan MCPResponse, 1)`.
- Inspect the received `MCPResponse` in the `select` block. If `Error` is not nil, return it as the third return value. The MCP SDK automatically sets `IsError: true` and includes the error message in the tool result.

```go
select {
case reply := <-replyChan:
	if reply.Error != nil {
		return nil, PostMessageOutput{}, reply.Error
	}
	return nil, PostMessageOutput{Response: reply.Response}, nil
case <-ctx.Done():
// ...
```

## Alternatives Considered

### Alternative A: Add a separate error channel
Instead of wrapping the response in `MCPResponse`, we could have added `ErrChan chan error` to `MCPRequestMsg`.
- **Reason for rejection**: More complex synchronization, higher chance of leaks/deadlocks, and less idiomatic Go than a single response structure containing both values.

### Alternative B: Parsing string prefix
We could have parsed the response string for the `"Error: "` prefix.
- **Reason for rejection**: Fragile, prone to false positives if a successful message starts with `"Error: "`.

## Test Plan
- Run existing Go tests to verify no regressions: `go test ./...`
- Manually verify that compilation succeeds and that the TUI and MCP server start without errors.

</details>

## Review Points
Please check if the type definition changes and error returns in `server.go` follow Go's standard practices and integrate cleanly with the Bubble Tea TUI.
