### PR TITLE
feat(trace): support local Jaeger tracing via Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ otomo is a Slack bot powered by gen-AI.
 TBD
 
 
+## Local Development with Tracing
+
+To run the application with distributed tracing enabled locally:
+
+1. Start the Jaeger container using Docker Compose:
+   ```bash
+   docker compose up -d
+   ```
+2. Ensure `config.toml` has tracing enabled:
+   ```toml
+   [otel]
+   enabled = true
+   exporter = "otlp"
+   service_name = "otomo"
+   ```
+3. Run the application with the `OTEL_EXPORTER_OTLP_INSECURE` environment variable set to `true`:
+   ```bash
+   OTEL_EXPORTER_OTLP_INSECURE=true go run ./cmd/otomo/main.go server
+   ```
+   Alternatively, you can set `OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"`.
+4. Open the Jaeger UI in your browser at http://localhost:16686 to view and analyze your traces.
+
 ## License
 
 MIT

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.60
+    container_name: otomo-jaeger
+    ports:
+      # Jaeger Web UI
+      - "16686:16686"
+      # OpenTelemetry Protocol HTTP
+      - "4318:4318"
+      # OpenTelemetry Protocol gRPC
+      - "4317:4317"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    restart: unless-stopped

--- a/internal/infra/trace/trace_test.go
+++ b/internal/infra/trace/trace_test.go
@@ -45,3 +45,18 @@ func TestInitTracerUnsupportedExporter(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, shutdown)
 }
+
+func TestInitTracerEnabledOtlp(t *testing.T) {
+	oldConfig := config.Config
+	defer func() { config.Config = oldConfig }()
+
+	config.Config.Otel.Enabled = true
+	config.Config.Otel.Exporter = "otlp"
+	config.Config.Otel.ServiceName = "test-service"
+	shutdown, err := InitTracer(context.Background())
+	assert.NoError(t, err)
+	assert.NotNil(t, shutdown)
+	err = shutdown(context.Background())
+	assert.NoError(t, err)
+}
+


### PR DESCRIPTION
## Why this change is necessary
To allow developers to collect, inspect, and debug OpenTelemetry tracing spans generated by the `otomo` application in their local development environment using Jaeger.

## Approach
- Created a `compose.yaml` in the root directory to launch a local Jaeger instance using the All-in-One image.
- Exposed OTLP/HTTP (`4318`), OTLP/gRPC (`4317`), and Web UI (`16686`) ports.
- Added a unit test case for the OTLP trace exporter verification in `internal/infra/trace/trace_test.go`.
- Appended a local development tracing setup guide to `README.md` which instructs developers to run Docker Compose and set the `OTEL_EXPORTER_OTLP_INSECURE=true` environment variable to ensure spans are successfully exported without TLS to the local Jaeger.

## Design Documents
<details>
<summary>2026-06-27-local-jaeger-tracing-design.md (Click to expand)</summary>

# Specification: Local Jaeger Tracing Setup

## 1. Goal
Provide a way to collect and visualize OpenTelemetry traces of the `otomo` application in the local development environment using Jaeger.

## 2. Requirements & Constraints
- Use Jaeger for visualization.
- Use Docker Compose to launch Jaeger.
- Enable tracing by modifying the local configuration file directly.

## 3. Architecture & Configuration
### 3.1 Docker Compose Configuration
Create a `compose.yaml` file in the root directory of the project.

```yaml
services:
  jaeger:
    image: jaegertracing/all-in-one:1.60
    container_name: otomo-jaeger
    ports:
      # Jaeger Web UI
      - "16686:16686"
      # OpenTelemetry Protocol HTTP (Default port for OTel HTTP exporter)
      - "4318:4318"
      # OpenTelemetry Protocol gRPC (For future compatibility)
      - "4317:4317"
    environment:
      - COLLECTOR_OTLP_ENABLED=true
    restart: unless-stopped
```

### 3.2 Application Configuration
Update `config.toml` to enable the Otel tracer with OTLP HTTP exporter.

```toml
[otel]
enabled = true
exporter = "otlp"
service_name = "otomo"
```

## 4. Verification Plan
- Run `docker compose up -d` to start Jaeger.
- Verify Jaeger UI is accessible at `http://localhost:16686`.
- Run the `otomo` application locally.
- Trigger tracing spans (e.g., by sending API requests or slack events depending on application interface) and confirm the traces are visible in the Jaeger UI.

</details>

## Review Points
- Ensure the ports exposed in `compose.yaml` are suitable for local development.
- Check if the added `TestInitTracerEnabledOtlp` unit test is structured correctly.
- Review the instructions appended to `README.md` for clarity and correctness.
